### PR TITLE
fix: window buffer undefined error

### DIFF
--- a/examples/simple-login/src/calimeroSdk.js
+++ b/examples/simple-login/src/calimeroSdk.js
@@ -1,7 +1,7 @@
 import { CalimeroSdk } from "calimero-sdk";
 
 export const config = {
-  shardId: "fran-calimero-testnet",
+  shardId: "lal20-calimero-testnet",
   walletUrl: "https://localhost:1234",
   calimeroUrl: "https://api.development.calimero.network",
   calimeroWebSdkService: "http://localhost:3000",

--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calimero-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Javascript library to interact with Calimero private shards",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
+    "@types/bn.js": "^5.1.1",
     "@types/node": "^18.7.14",
     "@types/uuid": "^8.3.4",
     "browserify": "^16.2.3",

--- a/packages/calimero-sdk/src/web-sdk/CalimeroSdk.ts
+++ b/packages/calimero-sdk/src/web-sdk/CalimeroSdk.ts
@@ -17,7 +17,6 @@ const ALL_KEYS = 'all_keys';
 const WALLET_DATA = 'calimero_wallet_auth_key';
 const WALLET_AUTH = 'undefined_wallet_auth_key';
 
-window.Buffer = window.Buffer || Buffer;
 
 interface CalimeroConfig {
   shardId: string;
@@ -43,6 +42,7 @@ export class CalimeroSdk {
   }
 
   connect = async (): Promise<Calimero> => {
+    window.Buffer = Buffer;
     const xApiKey = localStorage.getItem(AUTH_TOKEN_KEY) || '';
     if(!xApiKey){
       console.log('Requires login first!');
@@ -203,6 +203,7 @@ export class WalletConnection extends nearAPI.WalletConnection {
   }
 
   addFunctionKey = async(contractAddress: string, methodNames: string[], allowance: BN, xApiKey: string): Promise<void> => {
+    window.Buffer = Buffer;
     let sender;
     let publicKey;
     try{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
       '@testing-library/user-event': ^13.5.0
       bn.js: ^5.2.1
       buffer: ^6.0.3
-      calimero-sdk: workspace:^0.0.2
+      calimero-sdk: workspace:^0.0.3
       near-api-js: ^1.1.0
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -59,7 +59,7 @@ importers:
 
   packages/calimero-sdk:
     specifiers:
-      '@types/bn.js': ^5.1.0
+      '@types/bn.js': ^5.1.1
       '@types/node': ^18.7.14
       '@types/uuid': ^8.3.4
       axios: ^0.27.2


### PR DESCRIPTION
# [SDK] window buffer undefined error fix
 
## Summary:
Update to calimero-sdk where window.buffer is only called from the frontend and cant be called in the backend without the website running.

Fixes # AM-872

## Test plan:
Tested on calimero-sdk login example by removing window.buffer and also on tictactoe example by removing window.buffer from whole file. Login / logout / add function key / contract call available and working correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added a test plan that prove my fix is effective or that my feature works
- [x] I squashed all commits and provided a meaningful commit message
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
